### PR TITLE
Delete styles for body from benefits.css

### DIFF
--- a/src/css/benefits.css
+++ b/src/css/benefits.css
@@ -3,14 +3,6 @@
 	height: 100px;
 }
 
-body {
-	font-family: Arial, sans-serif;
-	background-color: #111;
-	color: #fff;
-	margin: 0;
-	padding: 0;
-}
-
 .benefits-section {
 	padding: 40px;
 	text-align: center;


### PR DESCRIPTION
Видалено в з файлу benefits.css стилі для тегу body, які ламали світлу тему.